### PR TITLE
added helm-charts-sciencebeam-dependency-update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 venv
+helm/sciencebeam/charts
 
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,6 @@ COPY --chown=airflow:airflow docker "${DOCKER_SCRIPTS_DIR}"
 
 ENV HELM_CHARTS_DIR=/usr/local/airflow/helm
 COPY --chown=airflow:airflow helm ${HELM_CHARTS_DIR}
+RUN cd ${HELM_CHARTS_DIR}/sciencebeam \
+  && helm init --client-only \
+  && helm dep update

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,7 @@ helm-charts-get:
 	fi
 
 
-helm-charts-sciencebeam-dependency-update:
-	cd ./helm/sciencebeam && helm dep update
-
-
-helm-charts-update: helm-charts-get helm-charts-sciencebeam-dependency-update
+helm-charts-update: helm-charts-get
 
 
 build: helm-charts-update

--- a/Makefile
+++ b/Makefile
@@ -90,24 +90,31 @@ helm-charts-clone:
 	fi
 
 
-copy-helm-charts:
+helm-charts-copy:
 	mkdir -p ./helm
 	cp -r --dereference "$(SCIENCEBEAM_CHARTS_DIR)"/* ./helm/
 
 
-updated-helm-charts:
+helm-charts-get:
 	@if [ -d "$(SCIENCEBEAM_CHARTS_DIR)" ]; then \
-		$(MAKE) copy-helm-charts; \
+		$(MAKE) helm-charts-copy; \
 	else \
 		$(MAKE) helm-charts-clone; \
 	fi
 
 
-build: updated-helm-charts
+helm-charts-sciencebeam-dependency-update:
+	cd ./helm/sciencebeam && helm dep update
+
+
+helm-charts-update: helm-charts-get helm-charts-sciencebeam-dependency-update
+
+
+build: helm-charts-update
 	$(DOCKER_COMPOSE) build airflow-image
 
 
-build-dev: updated-helm-charts
+build-dev: helm-charts-update
 	# only dev compose file has "init" service defined
 	@if [ "$(DOCKER_COMPOSE)" = "$(DOCKER_COMPOSE_DEV)" ]; then \
 		$(DOCKER_COMPOSE) build init; \
@@ -123,7 +130,7 @@ watch: build-dev
 	$(DOCKER_COMPOSE) run --rm airflow-dev python -m pytest_watch
 
 
-start: updated-helm-charts
+start: helm-charts-update
 	$(eval SERVICE_NAMES = $(shell docker-compose config --services | grep -v 'airflow-dev'))
 	$(DOCKER_COMPOSE) up --build -d --scale airflow-worker=2 $(SERVICE_NAMES)
 


### PR DESCRIPTION
This is required to ensure that the (sciencebeam) dependencies are part of the helm chart.

This was missing when moving to the separate repo and was otherwise run locally. But now needs to be run in CI to be part of the image.