### PR TITLE
escape comma in helm values

### DIFF
--- a/dags/sciencebeam_convert.py
+++ b/dags/sciencebeam_convert.py
@@ -6,6 +6,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dagrun_operator import DagRunOrder
 from airflow.models import DAG, DagRun
 
+from sciencebeam_airflow.utils.container import escape_helm_set_value
+
 from sciencebeam_dag_ids import ScienceBeamDagIds
 
 from sciencebeam_dag_utils import (
@@ -58,7 +60,7 @@ DEPLOY_SCIENCEBEAM_ARGS_TEMPLATE = (
     --timeout 600s \
     --set "fullnameOverride={{ dag_run.conf.sciencebeam_release_name }}-sb" \
     {% for key, value in get_sciencebeam_deploy_args(dag_run.conf).items() %} \
-        --set "{{ key }}={{ value }}" \
+        --set "{{ key }}={{ escape_helm_set_value(value) }}" \
     {% endfor %}
     '''
 )
@@ -181,6 +183,9 @@ class ScienceBeamConvertMacros:
             for child_chart_name in child_chart_names:
                 helm_args['%s.replicaCount' % child_chart_name] = replica_count
         return helm_args
+
+    def escape_helm_set_value(self, helm_value: str) -> str:
+        return escape_helm_set_value(helm_value)
 
     def get_sciencebeam_child_chart_names(
             self, dag_run: DagRun, **_) -> List[str]:

--- a/sciencebeam_airflow/tools/deploy_sciencebeam.py
+++ b/sciencebeam_airflow/tools/deploy_sciencebeam.py
@@ -9,6 +9,7 @@ from sciencebeam_airflow.utils.io import (
 )
 from sciencebeam_airflow.utils.container import (
     GeneratedHelmDeployArgs,
+    format_helm_values_as_set_args,
     get_helm_deploy_command,
     get_helm_delete_command
 )
@@ -129,14 +130,6 @@ def _load_model_config(model_url: str) -> dict:
     return model_config
 
 
-def format_helm_args(helm_args: Dict[str, str]) -> str:
-    return ' '.join([
-        '--set "{key}={value}"'.format(key=key, value=value)
-        for key, value in helm_args.items()
-    ])
-
-
-
 def run(args: argparse.Namespace):
     model_config = _load_model_config(args.model_url)
     helm_args = get_model_sciencebeam_deploy_args(
@@ -160,8 +153,12 @@ def run(args: argparse.Namespace):
                 namespace=args.namespace,
                 release_name=release_name,
                 chart_name='$HELM_CHARTS_DIR/sciencebeam',
-                helm_args=' '.join([generated_helm_args, format_helm_args(helm_args)])
+                helm_args=' '.join([
+                    generated_helm_args,
+                    format_helm_values_as_set_args(helm_args)
+                ])
             )
+        LOGGER.info('command: %s', command)
         run_command(command, shell=True)
 
 

--- a/sciencebeam_airflow/utils/container.py
+++ b/sciencebeam_airflow/utils/container.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from tempfile import mkdtemp
 from shutil import rmtree
-from typing import Callable, List
+from typing import Callable, Dict, List
 
 import yaml
 
@@ -60,6 +60,17 @@ def _get_helm_preemptible_values(child_chart_names: List[str] = None) -> dict:
 def generate_run_name(name: str, suffix: str = '', other_suffix: str = '') -> str:
     name = '-'.join(s for s in [name, suffix, other_suffix] if s)
     return name[:63]
+
+
+def escape_helm_set_value(helm_value: str) -> str:
+    return str(helm_value).replace(',', r'\,')
+
+
+def format_helm_values_as_set_args(helm_values: Dict[str, str]) -> str:
+    return ' '.join([
+        '--set "{key}={value}"'.format(key=key, value=escape_helm_set_value(value))
+        for key, value in helm_values.items()
+    ])
 
 
 class GeneratedHelmDeployArgs:

--- a/tests/sciencebeam_convert_test.py
+++ b/tests/sciencebeam_convert_test.py
@@ -207,6 +207,21 @@ class TestScienceBeamConvert:
                 'fullnameOverride': FULL_CHART_NAME
             }
 
+        def test_should_escape_set_options_for_deployment(
+                self, dag, airflow_context, dag_run):
+            dag_run.conf = {
+                **DEFAULT_CONF,
+                'model': {
+                    'chart_args': {
+                        'extra': 'a,b'
+                    }
+                }
+            }
+            rendered_bash_command = _create_and_render_deploy_command(dag, airflow_context)
+            opt = parse_command_arg(rendered_bash_command, {'--set': [str]})
+            set_string_map = _parse_set_string_list(getattr(opt, 'set'))
+            assert set_string_map.get('extra') == r'a\,b'
+
         def test_should_set_replica_count_if_configured(
                 self, dag, airflow_context, dag_run):
             dag_run.conf = {

--- a/tests/utils/container_test.py
+++ b/tests/utils/container_test.py
@@ -1,6 +1,15 @@
 from sciencebeam_airflow.utils.container import (
+    escape_helm_set_value,
     get_helm_delete_command
 )
+
+
+class TestEscapeHelmSetValue:
+    def test_should_escape_comma(self):
+        assert escape_helm_set_value('a,b') == r'a\,b'
+
+    def test_should_convert_int_to_str(self):
+        assert escape_helm_set_value(123) == '123'
 
 
 class TestGetHelmDeleteCommand:


### PR DESCRIPTION
used comma in the segmentation model paths which breaks the deployment as helm then considers it another value. See https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set