### PR TITLE
allow eval name override via config.evaluate

### DIFF
--- a/dags/sciencebeam_dag_conf.py
+++ b/dags/sciencebeam_dag_conf.py
@@ -53,8 +53,12 @@ def get_file_list_path(output_data_path: str, dataset: dict, limit: int) -> str:
     return os.path.join(output_data_path, f'file-list{suffix}.lst')
 
 
-def get_eval_output_path(output_data_path: str, dataset: dict, limit: int) -> str:
-    dataset_eval_name = dataset.get('eval_name')
+def get_eval_output_path(
+        output_data_path: str,
+        dataset: dict,
+        limit: int,
+        eval_name: str = None) -> str:
+    dataset_eval_name = eval_name or dataset.get('eval_name')
     dataset_subset_name = dataset.get('subset_name')
     if dataset_eval_name:
         folder_name = f'{dataset_eval_name}'

--- a/dags/sciencebeam_watch_experiments.py
+++ b/dags/sciencebeam_watch_experiments.py
@@ -184,7 +184,12 @@ def get_conf_for_experiment_data(experiment_data):  # pylint: disable=too-many-l
     limit = experiment_data.get('limit', dataset.get('limit', default_limit))
     output_file_list = get_file_list_path(output_data_path, dataset=dataset, limit=limit)
     output_suffix = '.xml.gz'
-    eval_output_path = get_eval_output_path(output_data_path, dataset=dataset, limit=limit)
+    eval_output_path = get_eval_output_path(
+        output_data_path,
+        dataset=dataset,
+        limit=limit,
+        eval_name=experiment_data.get('config', {}).get('evaluate', {}).get('eval_name')
+    )
     resume = parse_bool(experiment_data.get('resume', True))
     return remove_none({
         **_get_copied_experiment_data_props(experiment_data),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-storage==1.31.2
 kubernetes==11.0.0
 psycopg2-binary==2.8.6
 redis==3.5.3
+six==1.15.0

--- a/tests/sciencebeam_watch_experiments_test.py
+++ b/tests/sciencebeam_watch_experiments_test.py
@@ -197,6 +197,23 @@ class TestScienceBeamWatchExperiments:
                 f'{DEFAULT_MODEL_NAME}/evaluation-results/{DATASET_EVAL_NAME_1}'
             )
 
+        def test_should_prefer_eval_name_from_config_evaluate(self):
+            assert get_conf_for_experiment_data({
+                **DEFAULT_EXPERIMENT_DATA,
+                'config': {
+                    'evaluate': {
+                        'eval_name': DATASET_EVAL_NAME_1
+                    }
+                },
+                'dataset': {
+                    **DEFAULT_EXPERIMENT_DATA['dataset'],
+                    'eval_name': 'other'
+                }
+            })['eval_output_path'] == (
+                f'{DEFAULT_SOURCE_DATA_PATH}-results/{NAMESPACE_1}/'
+                f'{DEFAULT_MODEL_NAME}/evaluation-results/{DATASET_EVAL_NAME_1}'
+            )
+
         def test_should_include_subset_name_and_limit_in_eval_output_path(self):
             assert get_conf_for_experiment_data({
                 **DEFAULT_EXPERIMENT_DATA,


### PR DESCRIPTION
this allows evaluation to be explicitly saved separately by specifying an `eval_name` (e.g. depending on the selected fields)

also had to add explicit `six` dependency due to import error of `collections_abc` in `six`.