### PR TITLE
fixed passing evaluation fields starting with a hyphen

### DIFF
--- a/dags/sciencebeam_evaluate.py
+++ b/dags/sciencebeam_evaluate.py
@@ -51,19 +51,19 @@ SCIENCEBEAM_EVALUATE_TEMPLATE = (
         --target-file-column=xml_url \
         --prediction-file-list \
         "{{ dag_run.conf.output_data_path }}/{{ dag_run.conf.output_file_list }}" \
-        --output-path "{{ dag_run.conf.eval_output_path }}" \
+        --output-path="{{ dag_run.conf.eval_output_path }}" \
         {% if dag_run.conf.get('config', {}).get('evaluate', {}).fields %} \
-            --fields "{{ dag_run.conf.config.evaluate.fields }}" \
+            --fields="{{ dag_run.conf.config.evaluate.fields }}" \
         {% endif %} \
         {% if dag_run.conf.get('config', {}).get('evaluate', {}).measures %} \
-            --measures "{{ dag_run.conf.config.evaluate.measures }}" \
+            --measures="{{ dag_run.conf.config.evaluate.measures }}" \
         {% endif %} \
         {% if dag_run.conf.get('config', {}).get('evaluate', {}).scoring_type_overrides %} \
-            --scoring-type-overrides "{{ dag_run.conf.config.evaluate.scoring_type_overrides }}" \
+            --scoring-type-overrides="{{ dag_run.conf.config.evaluate.scoring_type_overrides }}" \
         {% endif %} \
         --num_workers=10 \
         --skip-errors \
-        --limit "{{ dag_run.conf.limit }}"
+        --limit="{{ dag_run.conf.limit }}"
     '''
 )
 

--- a/tests/sciencebeam_evaluate_test.py
+++ b/tests/sciencebeam_evaluate_test.py
@@ -84,6 +84,20 @@ class TestScienceBeamEvaluate:
             opt = parse_command_arg(rendered_bash_command, {'--fields': str})
             assert getattr(opt, 'fields') == FIELD_1
 
+        def test_should_include_configured_fields_starting_with_hyphen(
+                self, dag, airflow_context, dag_run):
+            dag_run.conf = {
+                **DEFAULT_CONF,
+                'config': {
+                    'evaluate': {
+                        'fields': '-' + FIELD_1
+                    }
+                }
+            }
+            rendered_bash_command = _create_and_render_evaluate_command(dag, airflow_context)
+            opt = parse_command_arg(rendered_bash_command, {'--fields': str})
+            assert getattr(opt, 'fields') == '-' + FIELD_1
+
         def test_should_not_pass_metrics_argument_if_not_configured(
                 self, dag, airflow_context, dag_run):
             dag_run.conf = {


### PR DESCRIPTION
ScienceBeam Judge now supports relative fields to be specified, e.g. `--fields="-abstract"` to exclude the abstract from being evaluated.
But that breaks when passing it like `--fields "-abstract"` because the argument parser thinks that it is another argument.