### PR TITLE
Revert "upgrade airflow to 1.10.12 (#128)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:1.10.12
+FROM puckel/docker-airflow:1.10.9
 
 USER root
 
@@ -33,7 +33,7 @@ ENV PATH /usr/local/airflow/.local/bin:$PATH
 COPY --chown=airflow:airflow requirements.txt ./
 RUN pip install --user -r requirements.txt
 
-ARG install_dev="n"
+ARG install_dev
 COPY --chown=airflow:airflow requirements.dev.txt ./
 RUN if [ "${install_dev}" = "y" ]; then pip install --user -r requirements.dev.txt; fi
 


### PR DESCRIPTION
This reverts commit 4fb64d771a8533bc1f6c2278f202723ec0f8b849.

This was a bit rushed and not tested properly.

Appears to be failing to start:

```text
waiting 60s...
mkdir: cannot create directory ‘/usr/local/airflow/.local’: Permission denied
```