### PR TITLE
added document_field_evaluation bq schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,12 @@ dev-watch-slow:
 dev-test: dev-lint dev-pytest
 
 
+bq-document-field-evaluation-table-update-schema:
+	bq update \
+		--schema "sciencebeam_airflow/schemas/document_field_evaluation.bqschema.json" \
+		--table "$(GCP_PROJECT):$(SCIENCEBEAM_NAMESPACE).document_field_evaluation"
+
+
 helm-charts-clone:
 	@if [ ! -d 'helm' ]; then \
 		git clone https://github.com/elifesciences/sciencebeam-charts.git helm; \

--- a/sciencebeam_airflow/schemas/document_field_evaluation.bqschema.json
+++ b/sciencebeam_airflow/schemas/document_field_evaluation.bqschema.json
@@ -1,0 +1,82 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "created_timestamp",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "dataset_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "model_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "prediction_file",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "target_file",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "field_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "evaluation_method",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "scoring_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tp",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fp",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "fn",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "tn",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "expected",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "actual",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "expected_context",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "actual_context",
+    "type": "STRING"
+  }
+]


### PR DESCRIPTION
sciencebeam-judge have recently added the `expected_context` and `actual_context` columns.
This adds the updated schema of the table and a simple make target to update the schema.